### PR TITLE
Remove misleading artisan serve command [finishes #157645453]

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ cd nglocations
 composer install
 cp .env.example .env
 php artisan key:generate
-php artisan serve
 ```
 
 Pre-fill `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD` with database credentials. Then run:


### PR DESCRIPTION
Clean up documentation to remove misleading `php artisan serve` command, which will eventually throw up error due to missing database credentials.